### PR TITLE
URL Cleanup

### DIFF
--- a/ci/docker/os-image-stemcell-builder/scripts/update.sh
+++ b/ci/docker/os-image-stemcell-builder/scripts/update.sh
@@ -9,12 +9,12 @@ deb-src http://us.archive.ubuntu.com/ubuntu/ trusty main restricted
 deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates main restricted
 deb-src http://us.archive.ubuntu.com/ubuntu/ trusty-updates main restricted
 
-deb http://security.ubuntu.com/ubuntu trusty-security main restricted
-deb-src http://security.ubuntu.com/ubuntu trusty-security main restricted
-deb http://security.ubuntu.com/ubuntu trusty-security universe
-deb-src http://security.ubuntu.com/ubuntu trusty-security universe
-deb http://security.ubuntu.com/ubuntu trusty-security multiverse
-deb-src http://security.ubuntu.com/ubuntu trusty-security multiverse
+deb http://security.ubuntu.com/ubuntu/ trusty-security main restricted
+deb-src http://security.ubuntu.com/ubuntu/ trusty-security main restricted
+deb http://security.ubuntu.com/ubuntu/ trusty-security universe
+deb-src http://security.ubuntu.com/ubuntu/ trusty-security universe
+deb http://security.ubuntu.com/ubuntu/ trusty-security multiverse
+deb-src http://security.ubuntu.com/ubuntu/ trusty-security multiverse
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
 ## team. Also, please note that software in universe WILL NOT receive any
@@ -36,7 +36,7 @@ DEBIAN_FRONTEND=noninteractive apt-get -y  -o Dpkg::Options::="--force-confdef" 
 apt-get -y install curl
 
 # sometimes the cached lists seem to get out of date around here
-# http://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error/160179
+# https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error/160179
 rm -rf /var/lib/apt/lists/*
 
 apt-get -y update --fix-missing

--- a/stemcell_builder/stages/base_apt/apply.sh
+++ b/stemcell_builder/stages/base_apt/apply.sh
@@ -25,9 +25,9 @@ EOS
 else
 
 cat > $chroot/etc/apt/sources.list <<EOS
-deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME main universe multiverse
-deb http://archive.ubuntu.com/ubuntu $DISTRIB_CODENAME-updates main universe multiverse
-deb http://security.ubuntu.com/ubuntu $DISTRIB_CODENAME-security main universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ $DISTRIB_CODENAME main universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ $DISTRIB_CODENAME-updates main universe multiverse
+deb http://security.ubuntu.com/ubuntu/ $DISTRIB_CODENAME-security main universe multiverse
 EOS
 
 fi

--- a/stemcell_builder/stages/base_rhel/apply.sh
+++ b/stemcell_builder/stages/base_rhel/apply.sh
@@ -12,7 +12,7 @@ rpm --root $chroot --initdb
 case "${stemcell_operating_system_version}" in
   "7")
     release_package_url="/mnt/rhel/Packages/redhat-release-server-7.0-1.el7.x86_64.rpm"
-    epel_package_url="http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm"
+    epel_package_url="https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm"
     ;;
   *)
     echo "Unknown RHEL version: ${stemcell_operating_system_version}"

--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -89,7 +89,7 @@ else
     # on ppc64le compile from source as the .deb packages are not available
     # from the repo above
     wget http://download.rsyslog.com/liblogging/liblogging-1.0.5.tar.gz
-    wget http://www.rsyslog.com/download/files/download/rsyslog/rsyslog-8.15.0.tar.gz
+    wget https://www.rsyslog.com/download/files/download/rsyslog/rsyslog-8.15.0.tar.gz
     wget http://download.rsyslog.com/librelp/librelp-1.2.9.tar.gz
   "
 

--- a/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_aws_agent_settings/apply.sh
@@ -15,7 +15,7 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
       "Sources": [
         {
           "Type": "HTTP",
-          "URI": "http://169.254.169.254",
+          "URI": "https://169.254.169.254",
           "UserDataPath": "/latest/user-data",
           "InstanceIDPath": "/latest/meta-data/instance-id",
           "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key"

--- a/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
@@ -17,7 +17,7 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
       "Sources": [
         {
           "Type": "InstanceMetadata",
-          "URI": "http://169.254.169.254",
+          "URI": "https://169.254.169.254",
           "SettingsPath": "/computeMetadata/v1/instance/attributes/bosh_settings",
           "Headers": {
             "Metadata-Flavor": "Google"

--- a/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
@@ -31,7 +31,7 @@ cat > $agent_settings_file <<JSON
         },
         {
           "Type": "HTTP",
-          "URI": "http://169.254.169.254",
+          "URI": "https://169.254.169.254",
           "UserDataPath": "/latest/user-data",
           "InstanceIDPath": "/latest/meta-data/instance-id",
           "SSHKeysPath": "/latest/meta-data/public-keys/0/openssh-key"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://archive.ubuntu.com/ubuntu/pool/main/d/debootstrap/debootstrap_1.0.59_all.deb (200) with 1 occurrences could not be migrated:  
   ([https](https://archive.ubuntu.com/ubuntu/pool/main/d/debootstrap/debootstrap_1.0.59_all.deb) result AnnotatedConnectException).
* http://download.rsyslog.com/liblogging/liblogging-1.0.5.tar.gz (200) with 1 occurrences could not be migrated:  
   ([https](https://download.rsyslog.com/liblogging/liblogging-1.0.5.tar.gz) result SSLHandshakeException).
* http://download.rsyslog.com/librelp/librelp-1.2.9.tar.gz (200) with 1 occurrences could not be migrated:  
   ([https](https://download.rsyslog.com/librelp/librelp-1.2.9.tar.gz) result SSLHandshakeException).
* http://ports.ubuntu.com/ubuntu-ports/ (200) with 10 occurrences could not be migrated:  
   ([https](https://ports.ubuntu.com/ubuntu-ports/) result AnnotatedConnectException).
* http://us.archive.ubuntu.com/ubuntu/ (200) with 12 occurrences could not be migrated:  
   ([https](https://us.archive.ubuntu.com/ubuntu/) result AnnotatedConnectException).
* http://archive.ubuntu.com/ubuntu (301) with 2 occurrences could not be migrated:  
   ([https](https://archive.ubuntu.com/ubuntu) result AnnotatedConnectException).
* http://security.ubuntu.com/ubuntu (301) with 7 occurrences could not be migrated:  
   ([https](https://security.ubuntu.com/ubuntu) result AnnotatedConnectException).
* http://archive.ubuntu.com/ubuntu/pool/main/d/debootstrap/debootstrap_1.0.67_all.deb (404) with 1 occurrences could not be migrated:  
   ([https](https://archive.ubuntu.com/ubuntu/pool/main/d/debootstrap/debootstrap_1.0.67_all.deb) result AnnotatedConnectException).
* http://mirror.centos.org/centos/7/os/x86_64/Packages/centos-release-7-3.1611.el7.centos.x86_64.rpm (404) with 1 occurrences could not be migrated:  
   ([https](https://mirror.centos.org/centos/7/os/x86_64/Packages/centos-release-7-3.1611.el7.centos.x86_64.rpm) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://169.254.169.254 (AnnotatedConnectException) with 3 occurrences migrated to:  
  https://169.254.169.254 ([https](https://169.254.169.254) result ConnectTimeoutException).
* http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm (404) with 1 occurrences migrated to:  
  https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm ([https](https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error/160179 with 1 occurrences migrated to:  
  https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error/160179 ([https](https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error/160179) result 200).
* http://www.rsyslog.com/download/files/download/rsyslog/rsyslog-8.15.0.tar.gz with 1 occurrences migrated to:  
  https://www.rsyslog.com/download/files/download/rsyslog/rsyslog-8.15.0.tar.gz ([https](https://www.rsyslog.com/download/files/download/rsyslog/rsyslog-8.15.0.tar.gz) result 200).