### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -509,7 +509,7 @@ ideas.  The password hashing algorithm was designed by David Mazieres
 
 There's a paper on the algorithm that explains its design decisions:
 
-http://www.usenix.org/events/usenix99/provos.html
+https://www.usenix.org/events/usenix99/provos.html
 
 Some of the tricks in BF_ROUND might be inspired by Eric Young's
 Blowfish library (I can't be sure if I would think of something if I
@@ -799,7 +799,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 >>> escape_utils-1.0.1
 
-Copyright (c) 2010-2013 Brian Lopez - http://github.com/brianmario
+Copyright (c) 2010-2013 Brian Lopez - https://github.com/brianmario
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -840,7 +840,7 @@ escape_utils-1.0.1.tar.gz/escape_utils-1.0.1.tar/ escape_utils-1.0.1/ ext/ escap
 
 (The MIT License)
 
-Copyright (c) 2010-2013 {geemus (Wesley Beary)}[http://github.com/geemus]
+Copyright (c) 2010-2013 {geemus (Wesley Beary)}[https://github.com/geemus]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -865,7 +865,7 @@ SOFTWARE.
 
 (The MIT License)
 
-Copyright (c) 2010-2013 (Wesley Beary)[http://github.com/geemus]
+Copyright (c) 2010-2013 (Wesley Beary)[https://github.com/geemus]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -945,7 +945,7 @@ ffi-1.9.3.tar (1).gz\ffi-1.9.3.tar\ffi-1.9.3\ext\ffi_c\libffi\msvcc.sh
 # The contents of this file are subject to the Mozilla Public License Version
 # 1.1 (the "License"); you may not use this file except in compliance with
 # the License. You may obtain a copy of the License at
-# http://www.mozilla.org/MPL/
+# https://www.mozilla.org/MPL/
 #
 # Software distributed under the License is distributed on an "AS IS" basis,
 # WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
@@ -993,7 +993,7 @@ ffi-1.9.3.tar.gz\ffi-1.9.3.tar\ffi-1.9.3\ext\ffi_c\libffi\testsuite\libffi.speci
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; see the file COPYING3.  If not see
-# <http://www.gnu.org/licenses/>.
+# <https://www.gnu.org/licenses/>.
 
 
 >>> fog-1.14.0
@@ -1002,7 +1002,7 @@ Copyright
 
 (The MIT License)
 
-Copyright (c) 2013 [geemus (Wesley Beary)](http://github.com/geemus)
+Copyright (c) 2013 [geemus (Wesley Beary)](https://github.com/geemus)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -1055,7 +1055,7 @@ Copyright
 
 (The MIT License)
 
-Copyright (c) 2009 {geemus (Wesley Beary)}[http://github.com/geemus]
+Copyright (c) 2009 {geemus (Wesley Beary)}[https://github.com/geemus]
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -1395,7 +1395,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 >>> mysql2-0.3.11
 
-Copyright (c) 2010-2011 Brian Lopez - http://github.com/brianmario
+Copyright (c) 2010-2011 Brian Lopez - https://github.com/brianmario
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -1621,11 +1621,11 @@ ADDITIONAL LICENSE INFORMATION:
    Copyright 1999-2006 The Apache Software Foundation
 
    This product includes software developed at
-   The Apache Software Foundation (http://www.apache.org/).
+   The Apache Software Foundation (https://www.apache.org/).
 
    Portions of this software were originally based on the following:
-     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+     - software copyright (c) 1999, IBM Corporation., https://www.ibm.com.
+     - software copyright (c) 1999, Sun Microsystems., https://www.sun.com.
      - voluntary contributions made by Paul Eng on behalf of the
        Apache Software Foundation that were originally developed at iClick, Inc.,
        software copyright (c) 1999.
@@ -1635,12 +1635,12 @@ ADDITIONAL LICENSE INFORMATION:
 
 Copyright (c) 2008 - 2010:
 
-* {Aaron Patterson}[http://tenderlovemaking.com]
+* {Aaron Patterson}[https://tenderlovemaking.com]
 * {Mike Dalessio}[http://mike.daless.io]
 * {Charles Nutter}[http://blog.headius.com]
-* {Sergio Arbeo}[http://www.serabe.com]
-* {Patrick Mahoney}[http://polycrystal.org]
-* {Yoko Harada}[http://yokolet.blogspot.com]
+* {Sergio Arbeo}[https://www.serabe.com]
+* {Patrick Mahoney}[https://polycrystal.org]
+* {Yoko Harada}[https://yokolet.blogspot.com]
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -1705,12 +1705,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 Copyright (c) 2008 - 2012:
 
-* {Aaron Patterson}[http://tenderlovemaking.com]
+* {Aaron Patterson}[https://tenderlovemaking.com]
 * {Mike Dalessio}[http://mike.daless.io]
 * {Charles Nutter}[http://blog.headius.com]
-* {Sergio Arbeo}[http://www.serabe.com]
-* {Patrick Mahoney}[http://polycrystal.org]
-* {Yoko Harada}[http://yokolet.blogspot.com]
+* {Sergio Arbeo}[https://www.serabe.com]
+* {Patrick Mahoney}[https://polycrystal.org]
+* {Yoko Harada}[https://yokolet.blogspot.com]
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -1906,7 +1906,7 @@ ADDITIONAL LICENSE INFORMATION:
 Copyright (C) 2007, 2008, 2009, 2010 Christian Neukirchen <purl.org/net/chneukirchen>
 
  Rack is freely distributable under the terms of an MIT-style license.
- See COPYING or http://www.opensource.org/licenses/mit-license.php.
+ See COPYING or https://www.opensource.org/licenses/mit-license.php.
 
  The Rack main module, serving as a namespace for all core Rack
  modules and classes.
@@ -2103,7 +2103,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 >>> rest-client-1.6.7
 
-Released under the MIT License: http://www.opensource.org/licenses/mit-license.php
+Released under the MIT License: https://www.opensource.org/licenses/mit-license.php
 
 Copyright (c) 2003, 2004 Jim Weirich
 
@@ -2636,7 +2636,7 @@ simplecov-html-0.7.1.gem\data.tar.gz\data.tar\assets\javascripts\libraries\jquer
 
 Copyright 2011, John Resig
   Dual licensed under the MIT or GPL Version 2 licenses.
-  http://jquery.org/license
+  https://jquery.org/license
 
 
 >>> sinatra-0.9.2
@@ -2888,7 +2888,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 >>> tilt-1.3.4
 
-Copyright (c) 2010 Ryan Tomayko <http://tomayko.com/about>
+Copyright (c) 2010 Ryan Tomayko <https://tomayko.com/about>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -2910,7 +2910,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 >>> tilt-1.4.1
 
-Copyright (c) 2010 Ryan Tomayko <http://tomayko.com/about>
+Copyright (c) 2010 Ryan Tomayko <https://tomayko.com/about>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -3174,7 +3174,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 >>> yajl-ruby-0.8.2
 
-Copyright (c) 2008-2011 Brian Lopez - http://github.com/brianmario
+Copyright (c) 2008-2011 Brian Lopez - https://github.com/brianmario
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -3198,7 +3198,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 >>> yajl-ruby-1.1.0
 
-Copyright (c) 2008-2011 Brian Lopez - http://github.com/brianmario
+Copyright (c) 2008-2011 Brian Lopez - https://github.com/brianmario
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -3306,7 +3306,7 @@ Licensed under the Apache License, Version 2.0 (the "License"). You
 may not use this file except in compliance with the License. A copy of
 the License is located at
 
-    http://aws.amazon.com/apache2.0/
+    https://aws.amazon.com/apache2.0/
 
 or in the "license" file accompanying this file. This file is
 distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
@@ -3411,7 +3411,7 @@ Artistic License, V2.0 is applicable to the following component(s).
   Although this library is free, please consider having your company
   setup a gittip if used by your company professionally.
 
-  http://www.gittip.com/djberg96/
+  https://www.gittip.com/djberg96/
 
 = Copyright
   (C) 2003-2014 Daniel J. Berger
@@ -3904,7 +3904,7 @@ ADDITIONAL LICENSE INFORMATION:
  *  (c) 2005-2007 Sam Stephenson
  *
  *  Prototype is freely distributable under the terms of an MIT-style license.
- *  For details, see the Prototype web site: http://www.prototypejs.org/
+ *  For details, see the Prototype web site: http://prototypejs.org/
 
 
 >>> json-1.5.1
@@ -3982,7 +3982,7 @@ Prototype JavaScript framework, version 1.6.0
 (c) 2005-2007 Sam Stephenson
 
 Prototype is freely distributable under the terms of an MIT-style license.
-For details, see the Prototype web site: http://www.prototypejs.org/
+For details, see the Prototype web site: http://prototypejs.org/
 
 
 > MIT Style
@@ -4103,7 +4103,7 @@ Prototype JavaScript framework, version 1.6.0
  *  (c) 2005-2007 Sam Stephenson
  *
  *  Prototype is freely distributable under the terms of an MIT-style license.
- *  For details, see the Prototype web site: http://www.prototypejs.org/
+ *  For details, see the Prototype web site: http://prototypejs.org/
 
 
 >>> logging-1.5.2
@@ -4118,18 +4118,18 @@ Ruby
 [PLEASE NOTE:  PIVOTAL SOFTWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE RUBY CLAUSE 6. PLEASE SEE THE APPENDIX TO REVIEW THE FULL TEXT OF THE RUBY CLAUSE 6 LICENSE.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE]
 
 MIME::Types for Ruby
-Homepage::  http://rubyforge.org/projects/mime-types/
+Homepage::  https://rubyforge.org/projects/mime-types/
 Copyright:: Copyright (c) 2003 - 2006 Austin Ziegler.
 Summary::   Ruby's licence, Perl Aristic Licence,
             GNU GPL version 2 (or later)
 
 The text of the Ruby licence can be found at:
-http://www.ruby-lang.org/en/LICENSE.txt
+https://www.ruby-lang.org/en/LICENSE.txt
 
 The text of the Perl Artistic Licence can be found at:
-http://www.perl.com/pub/a/language/misc/Artistic.html
+https://www.perl.com/pub/a/language/misc/Artistic.html
 
-The text of the GNU GPL can be found at: http://www.gnu.org/copyleft/gpl.html
+The text of the GNU GPL can be found at: https://www.gnu.org/copyleft/gpl.html
 
 If you do not accept one of these licences, you may not use this software.
 
@@ -4872,7 +4872,7 @@ USE OF THE PACKAGE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
          GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -5549,7 +5549,7 @@ That's all there is to it!
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -6193,7 +6193,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -6212,14 +6212,14 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.
 
 
 ===========================================================================
@@ -6231,7 +6231,7 @@ available (as would be noted above), you may obtain a copy of
 the source code corresponding to the binaries for such open
 source components and modifications thereto, if any, (the
 "Source Files"), by downloading the Source Files from Pivotal's website at
-http://www.pivotal.io/open-source, or by sending a request,
+https://www.pivotal.io/open-source, or by sending a request,
 with your name and address to: Pivotal Software, Inc., 3496 Deer Creek Rd,
 Palo Alto, CA 94304, Attention: General Counsel. All such requests should
 clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The stemcell should be rebuilt when you are making and testing BOSH-specific cha
 
 #### with published OS image
 
-The last two arguments to the rake command are the S3 bucket and key of the OS image to use (i.e. in the example below, the .tgz will be downloaded from [http://bosh-os-images.s3.amazonaws.com/bosh-centos-7-os-image.tgz](http://bosh-os-images.s3.amazonaws.com/bosh-centos-7-os-image.tgz)). More info at OS\_IMAGES.
+The last two arguments to the rake command are the S3 bucket and key of the OS image to use (i.e. in the example below, the .tgz will be downloaded from [https://bosh-os-images.s3.amazonaws.com/bosh-centos-7-os-image.tgz](https://bosh-os-images.s3.amazonaws.com/bosh-centos-7-os-image.tgz)). More info at OS\_IMAGES.
 
     $ bundle exec rake stemcell:build[aws,xen,ubuntu,trusty,go,bosh-os-images,bosh-ubuntu-trusty-os-image.tgz]
 

--- a/bosh-dev/spec/bosh/dev/download_adapter_spec.rb
+++ b/bosh-dev/spec/bosh/dev/download_adapter_spec.rb
@@ -10,7 +10,7 @@ module Bosh::Dev
 
       before(:each) { FileUtils.mkdir('/tmp') }
 
-      let(:string_uri) { 'http://a.sample.uri/requesting/a/test.yml' }
+      let(:string_uri) { 'https://a.sample.uri/requesting/a/test.yml' }
       let(:uri) { URI(string_uri) }
       let(:write_path) { '/tmp/test.yml' }
       let(:content) { 'content' }
@@ -52,7 +52,7 @@ module Bosh::Dev
 
         context 'when the response is a redirect' do
           before do
-            redirected_uri = 'http://otherdomin.uri/requesting/a/test.yml'
+            redirected_uri = 'https://otherdomin.uri/requesting/a/test.yml'
             stub_request(:get, string_uri).to_return(:status => 301, :headers => { 'Location' => redirected_uri })
             stub_request(:get, redirected_uri).to_return(:body => content)
           end
@@ -64,7 +64,7 @@ module Bosh::Dev
 
           context 'and the redirect is an infinite loop' do
             before do
-              redirected_uri = 'http://otherdomin.uri/requesting/a/test.yml'
+              redirected_uri = 'https://otherdomin.uri/requesting/a/test.yml'
               stub_request(:get, string_uri).to_return(:status => 301, :headers => { 'Location' => redirected_uri })
               stub_request(:get, redirected_uri).to_return(:status => 301, :headers => { 'Location' => string_uri })
             end
@@ -72,7 +72,7 @@ module Bosh::Dev
             it 'eventually terminates and returns an error' do
               expect {
                 subject.download(uri, write_path)
-              }.to raise_error(%r{infinite redirect loop while downloading 'http://a.sample.uri/requesting/a/test.yml'})
+              }.to raise_error(%r{infinite redirect loop while downloading 'https://a.sample.uri/requesting/a/test.yml'})
             end
           end
         end
@@ -141,7 +141,7 @@ module Bosh::Dev
         it 'raises an error' do
           expect {
             subject.download(uri, write_path)
-          }.to raise_error(%r{error 500 Internal Server Error while downloading 'http://a.sample.uri/requesting/a/test.yml'})
+          }.to raise_error(%r{error 500 Internal Server Error while downloading 'https://a.sample.uri/requesting/a/test.yml'})
         end
 
         context 'and the response has a body' do
@@ -150,7 +150,7 @@ module Bosh::Dev
           it 'raises an error containing the body' do
             expect {
               subject.download(uri, write_path)
-            }.to raise_error(%r{error 400 Bad Request while downloading 'http://a.sample.uri/requesting/a/test.yml': Missing param foo})
+            }.to raise_error(%r{error 400 Bad Request while downloading 'https://a.sample.uri/requesting/a/test.yml': Missing param foo})
           end
         end
       end
@@ -168,7 +168,7 @@ module Bosh::Dev
       end
 
       context 'when a proxy is available' do
-        before { stub_const('ENV', 'http_proxy' => 'http://proxy.example.com:1234') }
+        before { stub_const('ENV', 'http_proxy' => 'https://proxy.example.com:1234') }
 
         it 'uses the proxy' do
           net_http_mock = class_double('Net::HTTP').as_stubbed_const
@@ -179,7 +179,7 @@ module Bosh::Dev
       end
 
       context 'when a proxy is available and contains the user and password' do
-        before { stub_const('ENV', 'http_proxy' => 'http://user:password@proxy.example.com:1234') }
+        before { stub_const('ENV', 'http_proxy' => 'https://user:password@proxy.example.com:1234') }
 
         it 'uses the proxy' do
           net_http_mock = class_double('Net::HTTP').as_stubbed_const
@@ -190,7 +190,7 @@ module Bosh::Dev
       end
 
       context 'when some uris are specified to bypass the proxy' do
-        before { stub_const('ENV', 'http_proxy' => 'http://proxy.example.com:1234', 'no_proxy' => bypass_proxy_uris)}
+        before { stub_const('ENV', 'http_proxy' => 'https://proxy.example.com:1234', 'no_proxy' => bypass_proxy_uris)}
 
         context 'when the URL does not match the bypass_proxy_uris list' do
           let(:bypass_proxy_uris) { 'does.not.match,at.all' }

--- a/bosh-stemcell/OS_IMAGES.md
+++ b/bosh-stemcell/OS_IMAGES.md
@@ -1,7 +1,7 @@
 
 # OS Image Changes
 
-OS images are stored in S3 bucket [bosh-os-images](http://s3.amazonaws.com/bosh-os-images/).
+OS images are stored in S3 bucket [bosh-os-images](https://s3.amazonaws.com/bosh-os-images/).
 
 
 ## Ubuntu 14.04

--- a/bosh-stemcell/spec/os_image/ubuntu_trusty_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_trusty_spec.rb
@@ -102,9 +102,9 @@ describe 'Ubuntu 14.04 OS image', os_image: true do
         it { should contain 'deb http://ports.ubuntu.com/ubuntu-ports/ trusty-security multiverse' }
 
       else
-        it { should contain 'deb http://archive.ubuntu.com/ubuntu trusty main universe multiverse' }
-        it { should contain 'deb http://archive.ubuntu.com/ubuntu trusty-updates main universe multiverse' }
-        it { should contain 'deb http://security.ubuntu.com/ubuntu trusty-security main universe multiverse' }
+        it { should contain 'deb http://archive.ubuntu.com/ubuntu/ trusty main universe multiverse' }
+        it { should contain 'deb http://archive.ubuntu.com/ubuntu/ trusty-updates main universe multiverse' }
+        it { should contain 'deb http://security.ubuntu.com/ubuntu/ trusty-security main universe multiverse' }
       end
     end
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/nu7hatch/gouuid/README.md
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/nu7hatch/gouuid/README.md
@@ -2,7 +2,7 @@
 
 This package provides immutable UUID structs and the functions
 NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
-and 5 UUIDs as specified in [RFC 4122](http://www.ietf.org/rfc/rfc4122.txt).
+and 5 UUIDs as specified in [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt).
 
 ## Installation
 
@@ -12,7 +12,7 @@ Use the `go` tool:
 
 ## Usage
 
-See [documentation and examples](http://godoc.org/github.com/nu7hatch/gouuid)
+See [documentation and examples](https://godoc.org/github.com/nu7hatch/gouuid)
 for more information.
 
 ## Copyright

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/CHANGELOG.md
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/CHANGELOG.md
@@ -31,7 +31,7 @@ Improvements:
     - `ginkgo build <path-to-package>` will now compile the package, producing a file named `package.test`
     - The compiled `package.test` file can be run directly.  This runs the tests in series.
     - To run precompiled tests in parallel, you can run: `ginkgo -p package.test`
-- Support `bootstrap`ping and `generate`ing [Agouti](http://agouti.org) specs.
+- Support `bootstrap`ping and `generate`ing [Agouti](https://agouti.org) specs.
 - `ginkgo generate` and `ginkgo bootstrap` now honor the package name already defined in a given directory
 - The `ginkgo` CLI ignores `SIGQUIT`.  Prevents its stack dump from interlacing with the underlying test suite's stack dump.
 - The `ginkgo` CLI now compiles tests into a temporary directory instead of the package directory.  This necessitates upgrading to Go v1.4+.

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/README.md
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/README.md
@@ -1,29 +1,29 @@
-![Ginkgo: A Golang BDD Testing Framework](http://onsi.github.io/ginkgo/images/ginkgo.png)
+![Ginkgo: A Golang BDD Testing Framework](https://onsi.github.io/ginkgo/images/ginkgo.png)
 
 [![Build Status](https://travis-ci.org/onsi/ginkgo.png)](https://travis-ci.org/onsi/ginkgo)
 
-Jump to the [docs](http://onsi.github.io/ginkgo/) to learn more.  To start rolling your Ginkgo tests *now* [keep reading](#set-me-up)!
+Jump to the [docs](https://onsi.github.io/ginkgo/) to learn more.  To start rolling your Ginkgo tests *now* [keep reading](#set-me-up)!
 
 To discuss Ginkgo and get updates, join the [google group](https://groups.google.com/d/forum/ginkgo-and-gomega).
 
 ## Feature List
 
-- Ginkgo uses Go's `testing` package and can live alongside your existing `testing` tests.  It's easy to [bootstrap](http://onsi.github.io/ginkgo/#bootstrapping-a-suite) and start writing your [first tests](http://onsi.github.io/ginkgo/#adding-specs-to-a-suite)
+- Ginkgo uses Go's `testing` package and can live alongside your existing `testing` tests.  It's easy to [bootstrap](https://onsi.github.io/ginkgo/#bootstrapping-a-suite) and start writing your [first tests](https://onsi.github.io/ginkgo/#adding-specs-to-a-suite)
 
 - Structure your BDD-style tests expressively:
-    - Nestable [`Describe` and `Context` container blocks](http://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context)
-    - [`BeforeEach` and `AfterEach` blocks](http://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach) for setup and teardown
-    - [`It` blocks](http://onsi.github.io/ginkgo/#individual-specs-) that hold your assertions
-    - [`JustBeforeEach` blocks](http://onsi.github.io/ginkgo/#separating-creation-and-configuration-justbeforeeach) that separate creation from configuration (also known as the subject action pattern).
-    - [`BeforeSuite` and `AfterSuite` blocks](http://onsi.github.io/ginkgo/#global-setup-and-teardown-beforesuite-and-aftersuite) to prep for and cleanup after a suite.
+    - Nestable [`Describe` and `Context` container blocks](https://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context)
+    - [`BeforeEach` and `AfterEach` blocks](https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach) for setup and teardown
+    - [`It` blocks](https://onsi.github.io/ginkgo/#individual-specs-) that hold your assertions
+    - [`JustBeforeEach` blocks](https://onsi.github.io/ginkgo/#separating-creation-and-configuration-justbeforeeach) that separate creation from configuration (also known as the subject action pattern).
+    - [`BeforeSuite` and `AfterSuite` blocks](https://onsi.github.io/ginkgo/#global-setup-and-teardown-beforesuite-and-aftersuite) to prep for and cleanup after a suite.
 
 - A comprehensive test runner that lets you:
-    - Mark specs as [pending](http://onsi.github.io/ginkgo/#pending-specs)
-    - [Focus](http://onsi.github.io/ginkgo/#focused-specs) individual specs, and groups of specs, either programmatically or on the command line
-    - Run your tests in [random order](http://onsi.github.io/ginkgo/#spec-permutation), and then reuse random seeds to replicate the same order.
-    - Break up your test suite into parallel processes for straightforward [test parallelization](http://onsi.github.io/ginkgo/#parallel-specs)
+    - Mark specs as [pending](https://onsi.github.io/ginkgo/#pending-specs)
+    - [Focus](https://onsi.github.io/ginkgo/#focused-specs) individual specs, and groups of specs, either programmatically or on the command line
+    - Run your tests in [random order](https://onsi.github.io/ginkgo/#spec-permutation), and then reuse random seeds to replicate the same order.
+    - Break up your test suite into parallel processes for straightforward [test parallelization](https://onsi.github.io/ginkgo/#parallel-specs)
 
-- `ginkgo`: a command line interface with plenty of handy command line arguments for [running your tests](http://onsi.github.io/ginkgo/#running-tests) and [generating](http://onsi.github.io/ginkgo/#generators) test files.  Here are a few choice examples:
+- `ginkgo`: a command line interface with plenty of handy command line arguments for [running your tests](https://onsi.github.io/ginkgo/#running-tests) and [generating](https://onsi.github.io/ginkgo/#generators) test files.  Here are a few choice examples:
     - `ginkgo -nodes=N` runs your tests in `N` parallel processes and print out coherent output in realtime
     - `ginkgo -cover` runs your tests using Golang's code coverage tool
     - `ginkgo convert` converts an XUnit-style `testing` package to a Ginkgo-style package
@@ -37,25 +37,25 @@ To discuss Ginkgo and get updates, join the [google group](https://groups.google
 
 - `ginkgo watch` [watches](https://onsi.github.io/ginkgo/#watching-for-changes) packages *and their dependencies* for changes, then reruns tests.  Run tests immediately as you develop!
 
-- Built-in support for testing [asynchronicity](http://onsi.github.io/ginkgo/#asynchronous-tests)
+- Built-in support for testing [asynchronicity](https://onsi.github.io/ginkgo/#asynchronous-tests)
 
-- Built-in support for [benchmarking](http://onsi.github.io/ginkgo/#benchmark-tests) your code.  Control the number of benchmark samples as you gather runtimes and other, arbitrary, bits of numerical information about your code. 
+- Built-in support for [benchmarking](https://onsi.github.io/ginkgo/#benchmark-tests) your code.  Control the number of benchmark samples as you gather runtimes and other, arbitrary, bits of numerical information about your code. 
 
 - [Completions for Sublime Text](https://github.com/onsi/ginkgo-sublime-completions): just use [Package Control](https://sublime.wbond.net/) to install `Ginkgo Completions`.
 
-- Straightforward support for third-party testing libraries such as [Gomock](https://code.google.com/p/gomock/) and [Testify](https://github.com/stretchr/testify).  Check out the [docs](http://onsi.github.io/ginkgo/#third-party-integrations) for details.
+- Straightforward support for third-party testing libraries such as [Gomock](https://code.google.com/p/gomock/) and [Testify](https://github.com/stretchr/testify).  Check out the [docs](https://onsi.github.io/ginkgo/#third-party-integrations) for details.
 
 - A modular architecture that lets you easily:
-    - Write [custom reporters](http://onsi.github.io/ginkgo/#writing-custom-reporters) (for example, Ginkgo comes with a [JUnit XML reporter](http://onsi.github.io/ginkgo/#generating-junit-xml-output) and a TeamCity reporter).
-    - [Adapt an existing matcher library (or write your own!)](http://onsi.github.io/ginkgo/#using-other-matcher-libraries) to work with Ginkgo
+    - Write [custom reporters](https://onsi.github.io/ginkgo/#writing-custom-reporters) (for example, Ginkgo comes with a [JUnit XML reporter](https://onsi.github.io/ginkgo/#generating-junit-xml-output) and a TeamCity reporter).
+    - [Adapt an existing matcher library (or write your own!)](https://onsi.github.io/ginkgo/#using-other-matcher-libraries) to work with Ginkgo
 
-## [Gomega](http://github.com/onsi/gomega): Ginkgo's Preferred Matcher Library
+## [Gomega](https://github.com/onsi/gomega): Ginkgo's Preferred Matcher Library
 
-Ginkgo is best paired with Gomega.  Learn more about Gomega [here](http://onsi.github.io/gomega/)
+Ginkgo is best paired with Gomega.  Learn more about Gomega [here](https://onsi.github.io/gomega/)
 
-## [Agouti](http://github.com/sclevine/agouti): A Golang Acceptance Testing Framework
+## [Agouti](https://github.com/sclevine/agouti): A Golang Acceptance Testing Framework
 
-Agouti allows you run WebDriver integration tests.  Learn more about Agouti [here](http://agouti.org)
+Agouti allows you run WebDriver integration tests.  Learn more about Agouti [here](https://agouti.org)
 
 ## Set Me Up!
 
@@ -85,16 +85,16 @@ With that said, it's great to know what your options are :)
 
 ### What Golang gives you out of the box
 
-Testing is a first class citizen in Golang, however Go's built-in testing primitives are somewhat limited: The [testing](http://golang.org/pkg/testing) package provides basic XUnit style tests and no assertion library.
+Testing is a first class citizen in Golang, however Go's built-in testing primitives are somewhat limited: The [testing](https://golang.org/pkg/testing) package provides basic XUnit style tests and no assertion library.
 
 ### Matcher libraries for Golang's XUnit style tests
 
 A number of matcher libraries have been written to augment Go's built-in XUnit style tests.  Here are two that have gained traction:
 
 - [testify](https://github.com/stretchr/testify)
-- [gocheck](http://labix.org/gocheck)
+- [gocheck](https://labix.org/gocheck)
 
-You can also use Ginkgo's matcher library [Gomega](https://github.com/onsi/gomega) in [XUnit style tests](http://onsi.github.io/gomega/#using-gomega-with-golangs-xunitstyle-tests)
+You can also use Ginkgo's matcher library [Gomega](https://github.com/onsi/gomega) in [XUnit style tests](https://onsi.github.io/gomega/#using-gomega-with-golangs-xunitstyle-tests)
 
 ### BDD style testing frameworks
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/config/config.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/config/config.go
@@ -1,7 +1,7 @@
 /*
 Ginkgo accepts a number of configuration options.
 
-These are documented [here](http://onsi.github.io/ginkgo/#the_ginkgo_cli)
+These are documented [here](https://onsi.github.io/ginkgo/#the_ginkgo_cli)
 
 You can also learn more via
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/ginkgo/main.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/ginkgo/main.go
@@ -1,7 +1,7 @@
 /*
 The Ginkgo CLI
 
-The Ginkgo CLI is fully documented [here](http://onsi.github.io/ginkgo/#the_ginkgo_cli)
+The Ginkgo CLI is fully documented [here](https://onsi.github.io/ginkgo/#the_ginkgo_cli)
 
 You can also learn more by running:
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/ginkgo_dsl.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/ginkgo_dsl.go
@@ -1,11 +1,11 @@
 /*
 Ginkgo is a BDD-style testing framework for Golang
 
-The godoc documentation describes Ginkgo's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo/
+The godoc documentation describes Ginkgo's API.  More comprehensive documentation (with examples!) is available at https://onsi.github.io/ginkgo/
 
-Ginkgo's preferred matcher library is [Gomega](http://github.com/onsi/gomega)
+Ginkgo's preferred matcher library is [Gomega](https://github.com/onsi/gomega)
 
-Ginkgo on Github: http://github.com/onsi/ginkgo
+Ginkgo on Github: https://github.com/onsi/ginkgo
 
 Ginkgo is MIT-Licensed
 */
@@ -171,7 +171,7 @@ func CurrentGinkgoTestDescription() GinkgoTestDescription {
 //The optional info argument is passed to the test reporter and can be used to
 // provide the measurement data to a custom reporter with context.
 //
-//See http://onsi.github.io/ginkgo/#benchmark_tests for more details
+//See https://onsi.github.io/ginkgo/#benchmark_tests for more details
 type Benchmarker interface {
 	Time(name string, body func(), info ...interface{}) (elapsedTime time.Duration)
 	RecordValue(name string, value float64, info ...interface{})
@@ -497,7 +497,7 @@ func BeforeEach(body interface{}, timeout ...float64) bool {
 }
 
 //JustBeforeEach blocks are run before It blocks but *after* all BeforeEach blocks.  For more details,
-//read the [documentation](http://onsi.github.io/ginkgo/#separating_creation_and_configuration_)
+//read the [documentation](https://onsi.github.io/ginkgo/#separating_creation_and_configuration_)
 //
 //Like It blocks, BeforeEach blocks can be made asynchronous by providing a body function that accepts
 //a Done channel

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/reporters/default_reporter.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/reporters/default_reporter.go
@@ -3,7 +3,7 @@ Ginkgo's Default Reporter
 
 A number of command line flags are available to tweak Ginkgo's default output.
 
-These are documented [here](http://onsi.github.io/ginkgo/#running_tests)
+These are documented [here](https://onsi.github.io/ginkgo/#running_tests)
 */
 package reporters
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/reporters/junit_reporter.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/reporters/junit_reporter.go
@@ -2,7 +2,7 @@
 
 JUnit XML Reporter for Ginkgo
 
-For usage instructions: http://onsi.github.io/ginkgo/#generating_junit_xml_output
+For usage instructions: https://onsi.github.io/ginkgo/#generating_junit_xml_output
 
 */
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
@@ -3,7 +3,7 @@
 TeamCity Reporter for Ginkgo
 
 Makes use of TeamCity's support for Service Messages
-http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests
+https://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests
 */
 
 package reporters

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/gomega/README.md
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/gomega/README.md
@@ -1,14 +1,14 @@
-![Gomega: Ginkgo's Preferred Matcher Library](http://onsi.github.io/gomega/images/gomega.png)
+![Gomega: Ginkgo's Preferred Matcher Library](https://onsi.github.io/gomega/images/gomega.png)
 
 [![Build Status](https://travis-ci.org/onsi/gomega.png)](https://travis-ci.org/onsi/gomega)
 
-Jump straight to the [docs](http://onsi.github.io/gomega/) to learn about Gomega, including a list of [all available matchers](http://onsi.github.io/gomega/#provided-matchers).
+Jump straight to the [docs](https://onsi.github.io/gomega/) to learn about Gomega, including a list of [all available matchers](https://onsi.github.io/gomega/#provided-matchers).
 
 To discuss Gomega and get updates, join the [google group](https://groups.google.com/d/forum/ginkgo-and-gomega).
 
-## [Ginkgo](http://github.com/onsi/ginkgo): a BDD Testing Framework for Golang
+## [Ginkgo](https://github.com/onsi/ginkgo): a BDD Testing Framework for Golang
 
-Learn more about Ginkgo [here](http://onsi.github.io/ginkgo/)
+Learn more about Ginkgo [here](https://onsi.github.io/ginkgo/)
 
 ## License
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/gomega/gomega_dsl.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/gomega/gomega_dsl.go
@@ -1,13 +1,13 @@
 /*
 Gomega is the Ginkgo BDD-style testing framework's preferred matcher library.
 
-The godoc documentation describes Gomega's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/gomega/
+The godoc documentation describes Gomega's API.  More comprehensive documentation (with examples!) is available at https://onsi.github.io/gomega/
 
-Gomega on Github: http://github.com/onsi/gomega
+Gomega on Github: https://github.com/onsi/gomega
 
-Learn more about Ginkgo online: http://onsi.github.io/ginkgo
+Learn more about Ginkgo online: https://onsi.github.io/ginkgo
 
-Ginkgo on Github: http://github.com/onsi/ginkgo
+Ginkgo on Github: https://github.com/onsi/ginkgo
 
 Gomega is MIT-Licensed
 */

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/gomega/matchers/type_support.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/gomega/matchers/type_support.go
@@ -4,7 +4,7 @@ Gomega matchers
 This package implements the Gomega matchers and does not typically need to be imported.
 See the docs for Gomega for documentation on the matchers
 
-http://onsi.github.io/gomega/
+https://onsi.github.io/gomega/
 */
 package matchers
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/gomega/types/types.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/onsi/gomega/types/types.go
@@ -9,7 +9,7 @@ type GomegaTestingT interface {
 
 //All Gomega matchers must implement the GomegaMatcher interface
 //
-//For details on writing custom matchers, check out: http://onsi.github.io/gomega/#adding_your_own_matchers
+//For details on writing custom matchers, check out: https://onsi.github.io/gomega/#adding_your_own_matchers
 type GomegaMatcher interface {
 	Match(actual interface{}) (success bool, err error)
 	FailureMessage(actual interface{}) (message string)

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/stretchr/testify/assert/http_assertions.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/cloudfoundry/bosh-utils/internal/github.com/stretchr/testify/assert/http_assertions.go
@@ -22,7 +22,7 @@ func httpCode(handler http.HandlerFunc, mode, url string, values url.Values) int
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
-//  assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//  assert.HTTPSuccess(t, myHandler, "POST", "https://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, mode, url string, values url.Values) bool {
@@ -111,7 +111,7 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, mode, url string,
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
-//  assert.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//  assert.HTTPSuccess(myHandler, "POST", "https://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, mode, url string, values url.Values) bool {

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/CHANGELOG.md
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/CHANGELOG.md
@@ -3,7 +3,7 @@
 Improvements:
 
 - `Skip(message)` can be used to skip the current test.
-- Added `extensions/table` - a Ginkgo DSL for [Table Driven Tests](http://onsi.github.io/ginkgo/#table-driven-tests)
+- Added `extensions/table` - a Ginkgo DSL for [Table Driven Tests](https://onsi.github.io/ginkgo/#table-driven-tests)
 
 Bug Fixes:
 
@@ -44,7 +44,7 @@ Improvements:
     - `ginkgo build <path-to-package>` will now compile the package, producing a file named `package.test`
     - The compiled `package.test` file can be run directly.  This runs the tests in series.
     - To run precompiled tests in parallel, you can run: `ginkgo -p package.test`
-- Support `bootstrap`ping and `generate`ing [Agouti](http://agouti.org) specs.
+- Support `bootstrap`ping and `generate`ing [Agouti](https://agouti.org) specs.
 - `ginkgo generate` and `ginkgo bootstrap` now honor the package name already defined in a given directory
 - The `ginkgo` CLI ignores `SIGQUIT`.  Prevents its stack dump from interlacing with the underlying test suite's stack dump.
 - The `ginkgo` CLI now compiles tests into a temporary directory instead of the package directory.  This necessitates upgrading to Go v1.4+.

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/README.md
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/README.md
@@ -1,29 +1,29 @@
-![Ginkgo: A Golang BDD Testing Framework](http://onsi.github.io/ginkgo/images/ginkgo.png)
+![Ginkgo: A Golang BDD Testing Framework](https://onsi.github.io/ginkgo/images/ginkgo.png)
 
 [![Build Status](https://travis-ci.org/onsi/ginkgo.png)](https://travis-ci.org/onsi/ginkgo)
 
-Jump to the [docs](http://onsi.github.io/ginkgo/) to learn more.  To start rolling your Ginkgo tests *now* [keep reading](#set-me-up)!
+Jump to the [docs](https://onsi.github.io/ginkgo/) to learn more.  To start rolling your Ginkgo tests *now* [keep reading](#set-me-up)!
 
 To discuss Ginkgo and get updates, join the [google group](https://groups.google.com/d/forum/ginkgo-and-gomega).
 
 ## Feature List
 
-- Ginkgo uses Go's `testing` package and can live alongside your existing `testing` tests.  It's easy to [bootstrap](http://onsi.github.io/ginkgo/#bootstrapping-a-suite) and start writing your [first tests](http://onsi.github.io/ginkgo/#adding-specs-to-a-suite)
+- Ginkgo uses Go's `testing` package and can live alongside your existing `testing` tests.  It's easy to [bootstrap](https://onsi.github.io/ginkgo/#bootstrapping-a-suite) and start writing your [first tests](https://onsi.github.io/ginkgo/#adding-specs-to-a-suite)
 
 - Structure your BDD-style tests expressively:
-    - Nestable [`Describe` and `Context` container blocks](http://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context)
-    - [`BeforeEach` and `AfterEach` blocks](http://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach) for setup and teardown
-    - [`It` blocks](http://onsi.github.io/ginkgo/#individual-specs-) that hold your assertions
-    - [`JustBeforeEach` blocks](http://onsi.github.io/ginkgo/#separating-creation-and-configuration-justbeforeeach) that separate creation from configuration (also known as the subject action pattern).
-    - [`BeforeSuite` and `AfterSuite` blocks](http://onsi.github.io/ginkgo/#global-setup-and-teardown-beforesuite-and-aftersuite) to prep for and cleanup after a suite.
+    - Nestable [`Describe` and `Context` container blocks](https://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context)
+    - [`BeforeEach` and `AfterEach` blocks](https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach) for setup and teardown
+    - [`It` blocks](https://onsi.github.io/ginkgo/#individual-specs-) that hold your assertions
+    - [`JustBeforeEach` blocks](https://onsi.github.io/ginkgo/#separating-creation-and-configuration-justbeforeeach) that separate creation from configuration (also known as the subject action pattern).
+    - [`BeforeSuite` and `AfterSuite` blocks](https://onsi.github.io/ginkgo/#global-setup-and-teardown-beforesuite-and-aftersuite) to prep for and cleanup after a suite.
 
 - A comprehensive test runner that lets you:
-    - Mark specs as [pending](http://onsi.github.io/ginkgo/#pending-specs)
-    - [Focus](http://onsi.github.io/ginkgo/#focused-specs) individual specs, and groups of specs, either programmatically or on the command line
-    - Run your tests in [random order](http://onsi.github.io/ginkgo/#spec-permutation), and then reuse random seeds to replicate the same order.
-    - Break up your test suite into parallel processes for straightforward [test parallelization](http://onsi.github.io/ginkgo/#parallel-specs)
+    - Mark specs as [pending](https://onsi.github.io/ginkgo/#pending-specs)
+    - [Focus](https://onsi.github.io/ginkgo/#focused-specs) individual specs, and groups of specs, either programmatically or on the command line
+    - Run your tests in [random order](https://onsi.github.io/ginkgo/#spec-permutation), and then reuse random seeds to replicate the same order.
+    - Break up your test suite into parallel processes for straightforward [test parallelization](https://onsi.github.io/ginkgo/#parallel-specs)
 
-- `ginkgo`: a command line interface with plenty of handy command line arguments for [running your tests](http://onsi.github.io/ginkgo/#running-tests) and [generating](http://onsi.github.io/ginkgo/#generators) test files.  Here are a few choice examples:
+- `ginkgo`: a command line interface with plenty of handy command line arguments for [running your tests](https://onsi.github.io/ginkgo/#running-tests) and [generating](https://onsi.github.io/ginkgo/#generators) test files.  Here are a few choice examples:
     - `ginkgo -nodes=N` runs your tests in `N` parallel processes and print out coherent output in realtime
     - `ginkgo -cover` runs your tests using Golang's code coverage tool
     - `ginkgo convert` converts an XUnit-style `testing` package to a Ginkgo-style package
@@ -37,25 +37,25 @@ To discuss Ginkgo and get updates, join the [google group](https://groups.google
 
 - `ginkgo watch` [watches](https://onsi.github.io/ginkgo/#watching-for-changes) packages *and their dependencies* for changes, then reruns tests.  Run tests immediately as you develop!
 
-- Built-in support for testing [asynchronicity](http://onsi.github.io/ginkgo/#asynchronous-tests)
+- Built-in support for testing [asynchronicity](https://onsi.github.io/ginkgo/#asynchronous-tests)
 
-- Built-in support for [benchmarking](http://onsi.github.io/ginkgo/#benchmark-tests) your code.  Control the number of benchmark samples as you gather runtimes and other, arbitrary, bits of numerical information about your code. 
+- Built-in support for [benchmarking](https://onsi.github.io/ginkgo/#benchmark-tests) your code.  Control the number of benchmark samples as you gather runtimes and other, arbitrary, bits of numerical information about your code. 
 
 - [Completions for Sublime Text](https://github.com/onsi/ginkgo-sublime-completions): just use [Package Control](https://sublime.wbond.net/) to install `Ginkgo Completions`.
 
-- Straightforward support for third-party testing libraries such as [Gomock](https://code.google.com/p/gomock/) and [Testify](https://github.com/stretchr/testify).  Check out the [docs](http://onsi.github.io/ginkgo/#third-party-integrations) for details.
+- Straightforward support for third-party testing libraries such as [Gomock](https://code.google.com/p/gomock/) and [Testify](https://github.com/stretchr/testify).  Check out the [docs](https://onsi.github.io/ginkgo/#third-party-integrations) for details.
 
 - A modular architecture that lets you easily:
-    - Write [custom reporters](http://onsi.github.io/ginkgo/#writing-custom-reporters) (for example, Ginkgo comes with a [JUnit XML reporter](http://onsi.github.io/ginkgo/#generating-junit-xml-output) and a TeamCity reporter).
-    - [Adapt an existing matcher library (or write your own!)](http://onsi.github.io/ginkgo/#using-other-matcher-libraries) to work with Ginkgo
+    - Write [custom reporters](https://onsi.github.io/ginkgo/#writing-custom-reporters) (for example, Ginkgo comes with a [JUnit XML reporter](https://onsi.github.io/ginkgo/#generating-junit-xml-output) and a TeamCity reporter).
+    - [Adapt an existing matcher library (or write your own!)](https://onsi.github.io/ginkgo/#using-other-matcher-libraries) to work with Ginkgo
 
-## [Gomega](http://github.com/onsi/gomega): Ginkgo's Preferred Matcher Library
+## [Gomega](https://github.com/onsi/gomega): Ginkgo's Preferred Matcher Library
 
-Ginkgo is best paired with Gomega.  Learn more about Gomega [here](http://onsi.github.io/gomega/)
+Ginkgo is best paired with Gomega.  Learn more about Gomega [here](https://onsi.github.io/gomega/)
 
-## [Agouti](http://github.com/sclevine/agouti): A Golang Acceptance Testing Framework
+## [Agouti](https://github.com/sclevine/agouti): A Golang Acceptance Testing Framework
 
-Agouti allows you run WebDriver integration tests.  Learn more about Agouti [here](http://agouti.org)
+Agouti allows you run WebDriver integration tests.  Learn more about Agouti [here](https://agouti.org)
 
 ## Set Me Up!
 
@@ -85,16 +85,16 @@ With that said, it's great to know what your options are :)
 
 ### What Golang gives you out of the box
 
-Testing is a first class citizen in Golang, however Go's built-in testing primitives are somewhat limited: The [testing](http://golang.org/pkg/testing) package provides basic XUnit style tests and no assertion library.
+Testing is a first class citizen in Golang, however Go's built-in testing primitives are somewhat limited: The [testing](https://golang.org/pkg/testing) package provides basic XUnit style tests and no assertion library.
 
 ### Matcher libraries for Golang's XUnit style tests
 
 A number of matcher libraries have been written to augment Go's built-in XUnit style tests.  Here are two that have gained traction:
 
 - [testify](https://github.com/stretchr/testify)
-- [gocheck](http://labix.org/gocheck)
+- [gocheck](https://labix.org/gocheck)
 
-You can also use Ginkgo's matcher library [Gomega](https://github.com/onsi/gomega) in [XUnit style tests](http://onsi.github.io/gomega/#using-gomega-with-golangs-xunitstyle-tests)
+You can also use Ginkgo's matcher library [Gomega](https://github.com/onsi/gomega) in [XUnit style tests](https://onsi.github.io/gomega/#using-gomega-with-golangs-xunitstyle-tests)
 
 ### BDD style testing frameworks
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/config/config.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/config/config.go
@@ -1,7 +1,7 @@
 /*
 Ginkgo accepts a number of configuration options.
 
-These are documented [here](http://onsi.github.io/ginkgo/#the_ginkgo_cli)
+These are documented [here](https://onsi.github.io/ginkgo/#the_ginkgo_cli)
 
 You can also learn more via
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -2,7 +2,7 @@
 
 Table provides a simple DSL for Ginkgo-native Table-Driven Tests
 
-The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at https://onsi.github.io/ginkgo#table-driven-tests
 
 */
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/ginkgo/main.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/ginkgo/main.go
@@ -1,7 +1,7 @@
 /*
 The Ginkgo CLI
 
-The Ginkgo CLI is fully documented [here](http://onsi.github.io/ginkgo/#the_ginkgo_cli)
+The Ginkgo CLI is fully documented [here](https://onsi.github.io/ginkgo/#the_ginkgo_cli)
 
 You can also learn more by running:
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go
@@ -1,11 +1,11 @@
 /*
 Ginkgo is a BDD-style testing framework for Golang
 
-The godoc documentation describes Ginkgo's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo/
+The godoc documentation describes Ginkgo's API.  More comprehensive documentation (with examples!) is available at https://onsi.github.io/ginkgo/
 
-Ginkgo's preferred matcher library is [Gomega](http://github.com/onsi/gomega)
+Ginkgo's preferred matcher library is [Gomega](https://github.com/onsi/gomega)
 
-Ginkgo on Github: http://github.com/onsi/ginkgo
+Ginkgo on Github: https://github.com/onsi/ginkgo
 
 Ginkgo is MIT-Licensed
 */
@@ -171,7 +171,7 @@ func CurrentGinkgoTestDescription() GinkgoTestDescription {
 //The optional info argument is passed to the test reporter and can be used to
 // provide the measurement data to a custom reporter with context.
 //
-//See http://onsi.github.io/ginkgo/#benchmark_tests for more details
+//See https://onsi.github.io/ginkgo/#benchmark_tests for more details
 type Benchmarker interface {
 	Time(name string, body func(), info ...interface{}) (elapsedTime time.Duration)
 	RecordValue(name string, value float64, info ...interface{})
@@ -508,7 +508,7 @@ func BeforeEach(body interface{}, timeout ...float64) bool {
 }
 
 //JustBeforeEach blocks are run before It blocks but *after* all BeforeEach blocks.  For more details,
-//read the [documentation](http://onsi.github.io/ginkgo/#separating_creation_and_configuration_)
+//read the [documentation](https://onsi.github.io/ginkgo/#separating_creation_and_configuration_)
 //
 //Like It blocks, BeforeEach blocks can be made asynchronous by providing a body function that accepts
 //a Done channel

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
@@ -3,7 +3,7 @@ Ginkgo's Default Reporter
 
 A number of command line flags are available to tweak Ginkgo's default output.
 
-These are documented [here](http://onsi.github.io/ginkgo/#running_tests)
+These are documented [here](https://onsi.github.io/ginkgo/#running_tests)
 */
 package reporters
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
@@ -2,7 +2,7 @@
 
 JUnit XML Reporter for Ginkgo
 
-For usage instructions: http://onsi.github.io/ginkgo/#generating_junit_xml_output
+For usage instructions: https://onsi.github.io/ginkgo/#generating_junit_xml_output
 
 */
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
@@ -3,7 +3,7 @@
 TeamCity Reporter for Ginkgo
 
 Makes use of TeamCity's support for Service Messages
-http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests
+https://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests
 */
 
 package reporters

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/gomega/README.md
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/gomega/README.md
@@ -1,14 +1,14 @@
-![Gomega: Ginkgo's Preferred Matcher Library](http://onsi.github.io/gomega/images/gomega.png)
+![Gomega: Ginkgo's Preferred Matcher Library](https://onsi.github.io/gomega/images/gomega.png)
 
 [![Build Status](https://travis-ci.org/onsi/gomega.png)](https://travis-ci.org/onsi/gomega)
 
-Jump straight to the [docs](http://onsi.github.io/gomega/) to learn about Gomega, including a list of [all available matchers](http://onsi.github.io/gomega/#provided-matchers).
+Jump straight to the [docs](https://onsi.github.io/gomega/) to learn about Gomega, including a list of [all available matchers](https://onsi.github.io/gomega/#provided-matchers).
 
 To discuss Gomega and get updates, join the [google group](https://groups.google.com/d/forum/ginkgo-and-gomega).
 
-## [Ginkgo](http://github.com/onsi/ginkgo): a BDD Testing Framework for Golang
+## [Ginkgo](https://github.com/onsi/ginkgo): a BDD Testing Framework for Golang
 
-Learn more about Ginkgo [here](http://onsi.github.io/ginkgo/)
+Learn more about Ginkgo [here](https://onsi.github.io/ginkgo/)
 
 ## License
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/gomega/gexec/session.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/gomega/gexec/session.go
@@ -115,7 +115,7 @@ To assert that the command has exited it is more convenient to use the Exit matc
 	Eventually(s).Should(gexec.Exit())
 
 When the process exits because it has received a particular signal, the exit code will be 128+signal-value
-(See http://www.tldp.org/LDP/abs/html/exitcodes.html and http://man7.org/linux/man-pages/man7/signal.7.html)
+(See https://www.tldp.org/LDP/abs/html/exitcodes.html and http://man7.org/linux/man-pages/man7/signal.7.html)
 
 */
 func (s *Session) ExitCode() int {

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/gomega/gomega_dsl.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/gomega/gomega_dsl.go
@@ -1,13 +1,13 @@
 /*
 Gomega is the Ginkgo BDD-style testing framework's preferred matcher library.
 
-The godoc documentation describes Gomega's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/gomega/
+The godoc documentation describes Gomega's API.  More comprehensive documentation (with examples!) is available at https://onsi.github.io/gomega/
 
-Gomega on Github: http://github.com/onsi/gomega
+Gomega on Github: https://github.com/onsi/gomega
 
-Learn more about Ginkgo online: http://onsi.github.io/ginkgo
+Learn more about Ginkgo online: https://onsi.github.io/ginkgo
 
-Ginkgo on Github: http://github.com/onsi/ginkgo
+Ginkgo on Github: https://github.com/onsi/ginkgo
 
 Gomega is MIT-Licensed
 */

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/gomega/matchers/type_support.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/gomega/matchers/type_support.go
@@ -4,7 +4,7 @@ Gomega matchers
 This package implements the Gomega matchers and does not typically need to be imported.
 See the docs for Gomega for documentation on the matchers
 
-http://onsi.github.io/gomega/
+https://onsi.github.io/gomega/
 */
 package matchers
 

--- a/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/gomega/types/types.go
+++ b/src/github.com/cloudfoundry/stemcell-acceptance-tests/vendor/github.com/onsi/gomega/types/types.go
@@ -9,7 +9,7 @@ type GomegaTestingT interface {
 
 //All Gomega matchers must implement the GomegaMatcher interface
 //
-//For details on writing custom matchers, check out: http://onsi.github.io/gomega/#adding_your_own_matchers
+//For details on writing custom matchers, check out: https://onsi.github.io/gomega/#adding_your_own_matchers
 type GomegaMatcher interface {
 	Match(actual interface{}) (success bool, err error)
 	FailureMessage(actual interface{}) (message string)

--- a/stemcell_builder/etc/custom_rhel_yum.conf
+++ b/stemcell_builder/etc/custom_rhel_yum.conf
@@ -5,7 +5,7 @@ gpgcheck=0
 
 [epel]
 name=Extra Packages for Enterprise Linux 7 - x86_64
-baseurl=http://dl.fedoraproject.org/pub/epel/7/x86_64/
+baseurl=https://dl.fedoraproject.org/pub/epel/7/x86_64/
 
 failovermethod=priority
 gpgcheck=0

--- a/stemcell_builder/etc/custom_yum.conf
+++ b/stemcell_builder/etc/custom_yum.conf
@@ -1,6 +1,6 @@
 [main]
 cachedir=/var/cache/yum/$basearch/6.4
-baseurl=http://www.kernel.org/centos/6.4/os/$basearch/
+baseurl=https://www.kernel.org/centos/6.4/os/$basearch/
 # mirrorlist must be blank to override the default
 mirrorlist=
 keepcache=0
@@ -10,7 +10,7 @@ exactarch=1
 obsoletes=1
 gpgcheck=1
 installonly_limit=5
-bugtracker_url=http://bugs.centos.org/set_project.php?project_id=16&ref=http://bugs.centos.org/bug_report_page.php?category=yum
+bugtracker_url=https://bugs.centos.org/set_project.php?project_id=16&ref=http://bugs.centos.org/bug_report_page.php?category=yum
 distroverpkg=centos-release
 # reposdir must be blank to override the default
 reposdir=
@@ -20,7 +20,7 @@ exactarch=1
 obsoletes=1
 gpgcheck=1
 installonly_limit=5
-bugtracker_url=http://bugs.centos.org/set_project.php?project_id=16&ref=http://bugs.centos.org/bug_report_page.php?category=yum
+bugtracker_url=https://bugs.centos.org/set_project.php?project_id=16&ref=http://bugs.centos.org/bug_report_page.php?category=yum
 distroverpkg=centos-release
 # reposdir must be blank to override the default
 reposdir=
@@ -63,7 +63,7 @@ gpgcheck=0
 
 [epel]
 name=Extra Packages for Enterprise Linux 6 - $basearch
-baseurl=http://ftp.osuosl.org/pub/fedora-epel/6/$basearch/
+baseurl=https://ftp.osuosl.org/pub/fedora-epel/6/$basearch/
 
 failovermethod=priority
 gpgcheck=0

--- a/stemcell_builder/stages/bosh_sysctl/assets/60-bosh-sysctl-neigh-fix.conf
+++ b/stemcell_builder/stages/bosh_sysctl/assets/60-bosh-sysctl-neigh-fix.conf
@@ -1,5 +1,5 @@
 # Actively delete stale entries from the neighbor table regardless of its size
 # (Kernel started using this value in GC loop in commit 2724680).
-# http://wiki.wireshark.org/Gratuitous_ARP
+# https://wiki.wireshark.org/Gratuitous_ARP
 # http://linux-ip.net/html/ether-arp.html
 net.ipv4.neigh.default.gc_thresh1=0


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://blog.headius.com (200) with 2 occurrences could not be migrated:  
   ([https](https://blog.headius.com) result ClosedChannelException).
* http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/jsr166e/LongAdder.java?revision=1.8 (200) with 1 occurrences could not be migrated:  
   ([https](https://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/jsr166e/LongAdder.java?revision=1.8) result AnnotatedConnectException).
* http://linux-ip.net/html/ether-arp.html (200) with 1 occurrences could not be migrated:  
   ([https](https://linux-ip.net/html/ether-arp.html) result AnnotatedConnectException).
* http://man7.org/linux/man-pages/man7/signal.7.html (200) with 1 occurrences could not be migrated:  
   ([https](https://man7.org/linux/man-pages/man7/signal.7.html) result AnnotatedConnectException).
* http://mike.daless.io (200) with 2 occurrences could not be migrated:  
   ([https](https://mike.daless.io) result SSLHandshakeException).
* http://mirrorlist.centos.org/?release= (200) with 2 occurrences could not be migrated:  
   ([https](https://mirrorlist.centos.org/?release=) result AnnotatedConnectException).
* http://ports.ubuntu.com/ubuntu-ports/ (200) with 9 occurrences could not be migrated:  
   ([https](https://ports.ubuntu.com/ubuntu-ports/) result AnnotatedConnectException).
* http://rpms.adiscon.com/RPM-GPG-KEY-Adiscon (200) with 1 occurrences could not be migrated:  
   ([https](https://rpms.adiscon.com/RPM-GPG-KEY-Adiscon) result ConnectTimeoutException).
* http://archive.ubuntu.com/ubuntu (301) with 2 occurrences could not be migrated:  
   ([https](https://archive.ubuntu.com/ubuntu) result AnnotatedConnectException).
* http://www.prototypejs.org/ (301) with 3 occurrences could not be migrated:  
   ([https](https://www.prototypejs.org/) result SSLHandshakeException).
* http://security.ubuntu.com/ubuntu (301) with 1 occurrences could not be migrated:  
   ([https](https://security.ubuntu.com/ubuntu) result AnnotatedConnectException).
* http://rpms.adiscon.com/v8-stable/epel- (404) with 1 occurrences could not be migrated:  
   ([https](https://rpms.adiscon.com/v8-stable/epel-) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://rubyforge.org/projects/mime-types/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://rubyforge.org/projects/mime-types/ ([https](https://rubyforge.org/projects/mime-types/) result ConnectTimeoutException).
* http://a.sample.uri/requesting/a/test.yml (UnknownHostException) with 4 occurrences migrated to:  
  https://a.sample.uri/requesting/a/test.yml ([https](https://a.sample.uri/requesting/a/test.yml) result UnknownHostException).
* http://otherdomin.uri/requesting/a/test.yml (UnknownHostException) with 2 occurrences migrated to:  
  https://otherdomin.uri/requesting/a/test.yml ([https](https://otherdomin.uri/requesting/a/test.yml) result UnknownHostException).
* http://proxy.example.com:1234 (UnknownHostException) with 2 occurrences migrated to:  
  https://proxy.example.com:1234 ([https](https://proxy.example.com:1234) result UnknownHostException).
* http://user:password@proxy.example.com:1234 (UnknownHostException) with 1 occurrences migrated to:  
  https://user:password@proxy.example.com:1234 ([https](https://user:password@proxy.example.com:1234) result UnknownHostException).
* http://www.gittip.com/djberg96/ (UnknownHostException) with 1 occurrences migrated to:  
  https://www.gittip.com/djberg96/ ([https](https://www.gittip.com/djberg96/) result UnknownHostException).
* http://www.kernel.org/centos/6.4/os/ (301) with 1 occurrences migrated to:  
  https://www.kernel.org/centos/6.4/os/ ([https](https://www.kernel.org/centos/6.4/os/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://agouti.org with 4 occurrences migrated to:  
  https://agouti.org ([https](https://agouti.org) result 200).
* http://bosh-os-images.s3.amazonaws.com/bosh-centos-7-os-image.tgz with 2 occurrences migrated to:  
  https://bosh-os-images.s3.amazonaws.com/bosh-centos-7-os-image.tgz ([https](https://bosh-os-images.s3.amazonaws.com/bosh-centos-7-os-image.tgz) result 200).
* http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity with 2 occurrences migrated to:  
  https://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity ([https](https://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity) result 200).
* http://dl.fedoraproject.org/pub/epel/7/x86_64/ with 1 occurrences migrated to:  
  https://dl.fedoraproject.org/pub/epel/7/x86_64/ ([https](https://dl.fedoraproject.org/pub/epel/7/x86_64/) result 200).
* http://ftp.osuosl.org/pub/fedora-epel/6/ with 1 occurrences migrated to:  
  https://ftp.osuosl.org/pub/fedora-epel/6/ ([https](https://ftp.osuosl.org/pub/fedora-epel/6/) result 200).
* http://github.com/brianmario with 4 occurrences migrated to:  
  https://github.com/brianmario ([https](https://github.com/brianmario) result 200).
* http://github.com/geemus with 4 occurrences migrated to:  
  https://github.com/geemus ([https](https://github.com/geemus) result 200).
* http://github.com/onsi/ginkgo with 6 occurrences migrated to:  
  https://github.com/onsi/ginkgo ([https](https://github.com/onsi/ginkgo) result 200).
* http://github.com/onsi/gomega with 6 occurrences migrated to:  
  https://github.com/onsi/gomega ([https](https://github.com/onsi/gomega) result 200).
* http://github.com/sclevine/agouti with 2 occurrences migrated to:  
  https://github.com/sclevine/agouti ([https](https://github.com/sclevine/agouti) result 200).
* http://godoc.org/github.com/nu7hatch/gouuid with 1 occurrences migrated to:  
  https://godoc.org/github.com/nu7hatch/gouuid ([https](https://godoc.org/github.com/nu7hatch/gouuid) result 200).
* http://labix.org/gocheck with 2 occurrences migrated to:  
  https://labix.org/gocheck ([https](https://labix.org/gocheck) result 200).
* http://onsi.github.io/ginkgo/ with 57 occurrences migrated to:  
  https://onsi.github.io/ginkgo/ ([https](https://onsi.github.io/ginkgo/) result 200).
* http://onsi.github.io/ginkgo/images/ginkgo.png with 2 occurrences migrated to:  
  https://onsi.github.io/ginkgo/images/ginkgo.png ([https](https://onsi.github.io/ginkgo/images/ginkgo.png) result 200).
* http://onsi.github.io/gomega/ with 14 occurrences migrated to:  
  https://onsi.github.io/gomega/ ([https](https://onsi.github.io/gomega/) result 200).
* http://onsi.github.io/gomega/images/gomega.png with 2 occurrences migrated to:  
  https://onsi.github.io/gomega/images/gomega.png ([https](https://onsi.github.io/gomega/images/gomega.png) result 200).
* http://polycrystal.org with 2 occurrences migrated to:  
  https://polycrystal.org ([https](https://polycrystal.org) result 200).
* http://s3.amazonaws.com/bosh-os-images/ with 1 occurrences migrated to:  
  https://s3.amazonaws.com/bosh-os-images/ ([https](https://s3.amazonaws.com/bosh-os-images/) result 200).
* http://tenderlovemaking.com with 2 occurrences migrated to:  
  https://tenderlovemaking.com ([https](https://tenderlovemaking.com) result 200).
* http://wiki.wireshark.org/Gratuitous_ARP with 1 occurrences migrated to:  
  https://wiki.wireshark.org/Gratuitous_ARP ([https](https://wiki.wireshark.org/Gratuitous_ARP) result 200).
* http://www.apache.org/ with 1 occurrences migrated to:  
  https://www.apache.org/ ([https](https://www.apache.org/) result 200).
* http://www.gnu.org/copyleft/gpl.html with 1 occurrences migrated to:  
  https://www.gnu.org/copyleft/gpl.html ([https](https://www.gnu.org/copyleft/gpl.html) result 200).
* http://www.gnu.org/licenses/ with 3 occurrences migrated to:  
  https://www.gnu.org/licenses/ ([https](https://www.gnu.org/licenses/) result 200).
* http://www.gnu.org/philosophy/why-not-lgpl.html with 1 occurrences migrated to:  
  https://www.gnu.org/philosophy/why-not-lgpl.html ([https](https://www.gnu.org/philosophy/why-not-lgpl.html) result 200).
* http://www.google.com with 2 occurrences migrated to:  
  https://www.google.com ([https](https://www.google.com) result 200).
* http://www.ietf.org/rfc/rfc4122.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc4122.txt ([https](https://www.ietf.org/rfc/rfc4122.txt) result 200).
* http://www.serabe.com with 2 occurrences migrated to:  
  https://www.serabe.com ([https](https://www.serabe.com) result 200).
* http://www.tldp.org/LDP/abs/html/exitcodes.html with 1 occurrences migrated to:  
  https://www.tldp.org/LDP/abs/html/exitcodes.html ([https](https://www.tldp.org/LDP/abs/html/exitcodes.html) result 200).
* http://yokolet.blogspot.com with 2 occurrences migrated to:  
  https://yokolet.blogspot.com ([https](https://yokolet.blogspot.com) result 200).
* http://aws.amazon.com/apache2.0/ with 1 occurrences migrated to:  
  https://aws.amazon.com/apache2.0/ ([https](https://aws.amazon.com/apache2.0/) result 301).
* http://fsf.org/ with 2 occurrences migrated to:  
  https://fsf.org/ ([https](https://fsf.org/) result 301).
* http://golang.org/pkg/testing with 2 occurrences migrated to:  
  https://golang.org/pkg/testing ([https](https://golang.org/pkg/testing) result 301).
* http://jquery.org/license with 1 occurrences migrated to:  
  https://jquery.org/license ([https](https://jquery.org/license) result 301).
* http://onsi.github.io/ginkgo with 3 occurrences migrated to:  
  https://onsi.github.io/ginkgo ([https](https://onsi.github.io/ginkgo) result 301).
* http://tomayko.com/about with 2 occurrences migrated to:  
  https://tomayko.com/about ([https](https://tomayko.com/about) result 301).
* http://www.mozilla.org/MPL/ with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).
* http://www.opensource.org/licenses/mit-license.php with 2 occurrences migrated to:  
  https://www.opensource.org/licenses/mit-license.php ([https](https://www.opensource.org/licenses/mit-license.php) result 301).
* http://www.perl.com/pub/a/language/misc/Artistic.html with 1 occurrences migrated to:  
  https://www.perl.com/pub/a/language/misc/Artistic.html ([https](https://www.perl.com/pub/a/language/misc/Artistic.html) result 301).
* http://www.pivotal.io/open-source with 1 occurrences migrated to:  
  https://www.pivotal.io/open-source ([https](https://www.pivotal.io/open-source) result 301).
* http://www.sun.com with 1 occurrences migrated to:  
  https://www.sun.com ([https](https://www.sun.com) result 301).
* http://bugs.centos.org/set_project.php?project_id=16&ref=http://bugs.centos.org/bug_report_page.php?category=yum with 2 occurrences migrated to:  
  https://bugs.centos.org/set_project.php?project_id=16&ref=http://bugs.centos.org/bug_report_page.php?category=yum ([https](https://bugs.centos.org/set_project.php?project_id=16&ref=https://bugs.centos.org/bug_report_page.php?category=yum) result 302).
* http://www.ruby-lang.org/en/LICENSE.txt with 1 occurrences migrated to:  
  https://www.ruby-lang.org/en/LICENSE.txt ([https](https://www.ruby-lang.org/en/LICENSE.txt) result 302).
* http://www.usenix.org/events/usenix99/provos.html with 1 occurrences migrated to:  
  https://www.usenix.org/events/usenix99/provos.html ([https](https://www.usenix.org/events/usenix99/provos.html) result 302).
* http://www.ibm.com with 1 occurrences migrated to:  
  https://www.ibm.com ([https](https://www.ibm.com) result 303).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1 with 2 occurrences
* http://127.0.0.1:7788 with 2 occurrences
* http://127.0.0.1:7788/AfterSuiteDidRun with 2 occurrences
* http://127.0.0.1:7788/BeforeSuiteDidRun with 2 occurrences
* http://127.0.0.1:7788/SpecDidComplete with 2 occurrences
* http://127.0.0.1:7788/SpecSuiteDidEnd with 2 occurrences
* http://127.0.0.1:7788/SpecSuiteWillBegin with 2 occurrences
* http://127.0.0.1:7788/SpecWillRun with 2 occurrences
* http://localhost:6305/fake-path with 2 occurrences